### PR TITLE
Score構造体の変更

### DIFF
--- a/src/gameover.rs
+++ b/src/gameover.rs
@@ -54,7 +54,7 @@ fn setup(
         0.0,
     );
     commands.spawn((
-        Text2d::new(format!("{}{}", SCORE_TEXT, **score)),
+        Text2d::new(format!("{}{}", SCORE_TEXT, score.sum())),
         TextFont {
             font: asset_server.load(PATH_FONT),
             font_size: TEXT_SIZE,

--- a/src/ingame/fighter/ship.rs
+++ b/src/ingame/fighter/ship.rs
@@ -19,7 +19,6 @@ use crate::ingame::utils::prelude::*;
 const PATH_IMAGE: &str = "bevy-2dshooting-game/fighter-ship.png";
 const SIZE: Vec2 = Vec2::splat(32.0);
 const HP: usize = 1;
-const SCORE: usize = 10;
 const DEGREES: f32 = 180.0;
 const SCALE: Vec3 = Vec3::splat(1.0);
 const DIRECTION: Vec2 = Vec2::new(1.0, -0.05);
@@ -126,8 +125,8 @@ fn despawn(
             // debug!("despawn");
             events.send(FighterDespawnEvent(transform.translation.xy()));
             // trace!("send ShipDespawnEvent");
-            **score += SCORE;
-            // trace!("score: {}", **score);
+            score.fighter += 1;
+            // trace!("score.fighter: {}", score.fighter);
             **count -= 1;
             // trace!("count: {}", **count);
             commands.entity(entity).despawn();

--- a/src/ingame/scoreboard.rs
+++ b/src/ingame/scoreboard.rs
@@ -100,7 +100,7 @@ fn update_score(
 ) {
     let Ok(mut span) = query.get_single_mut() else { return };
     // update score
-    **span = score.to_string();
+    **span = score.sum().to_string();
 }
 
 fn update_life(
@@ -115,7 +115,7 @@ fn update_life(
 
 fn reset_score(mut score: ResMut<Score>) {
     // debug!("reset_score");
-    **score = 0;
+    *score = Score::reset();
 }
 
 fn all_despawn(

--- a/src/ingame/torpedo/ship.rs
+++ b/src/ingame/torpedo/ship.rs
@@ -19,7 +19,6 @@ use crate::ingame::utils::prelude::*;
 const PATH_IMAGE: &str = "bevy-2dshooting-game/torpedo-ship.png";
 const SIZE: Vec2 = Vec2::splat(32.0);
 const HP: usize = 3;
-const SCORE: usize = 30;
 const DEGREES: f32 = 180.0;
 const SCALE: Vec3 = Vec3::splat(1.0);
 const DIRECTION: Vec2 = Vec2::new(1.0, 0.0);
@@ -48,7 +47,7 @@ fn spawn(
     score: Res<Score>,
     query: Query<&Transform, With<MyCamera>>,
 ) {
-    if **score == 0 || **score % 100 != 0 { return }
+    if score.fighter == 0 || score.fighter % 10 != 0 { return }
     if **count >= MAX_COUNT { return }
 
     let mut rng = rand::thread_rng();
@@ -126,8 +125,8 @@ fn despawn(
             // debug!("despawn");
             events.send(TorpedoDespawnEvent(transform.translation.xy()));
             // trace!("send TorpedoDespawnEvent");
-            **score += SCORE;
-            // trace!("score: {}", **score);
+            score.torpedo += 1;
+            // trace!("score.torpedo: {}", score.torpedo);
             **count -= 1;
             // trace!("count: {}", **count);
             commands.entity(entity).despawn();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ const GAMETITLE: &str = "2Dシューティングゲーム";
 const WINDOW_SIZE: Vec2 = Vec2::new(640.0, 480.0);
 const PATH_FONT: &str = "fonts/misaki_gothic.ttf";
 
+const SCORE_FIGHTER: usize = 10;
+const SCORE_TORPEDO: usize = 50;
+
 #[derive(States, Debug, Clone, PartialEq, Eq, Hash)]
 enum AppState {
     Mainmenu,
@@ -19,11 +22,31 @@ enum AppState {
     Gameover,
 }
 
-#[derive(Resource, Deref, DerefMut)]
-struct Score(usize);
+#[derive(Resource)]
+struct Score {
+    fighter: usize,
+    torpedo: usize,
+}
 
 #[derive(Component)]
 struct MyCamera;
+
+impl Score {
+    fn new() -> Self {
+        Self { fighter: 0, torpedo: 0, }
+    }
+
+    fn sum(&self) -> usize {
+        let score_fighter = SCORE_FIGHTER * self.fighter;
+        let score_torpedo = SCORE_TORPEDO * self.torpedo;
+
+        score_fighter + score_torpedo
+    }
+
+    fn reset() -> Self {
+        Self::new()
+    }
+}
 
 fn main() {
     App::new()
@@ -44,7 +67,7 @@ fn main() {
             })
         )
         .insert_state(AppState::Mainmenu)
-        .insert_resource(Score(0))
+        .insert_resource(Score::new())
         .insert_resource(Time::<Fixed>::from_seconds(1.0 / 60.0))
         .add_systems(Startup, setup)
         .add_plugins(background::BackgroundPlugin)


### PR DESCRIPTION
Issue: #14

変更内容

Score構造体の属性を`fighter, torpedo`に変更

倒した敵の種類x撃破数でスコアを計算する`sum`メソッドを追加